### PR TITLE
Endpoints for the user registration

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -25,8 +25,8 @@ type User struct {
 	DBModel
 	FName    string
 	LName    string
-	UName    string
-	Password string
+	UName    string `gorm:"type:varchar(40); not null`
+	Password string `gorm:"type:varchar(40); not null`
 	Email    string
 	// 	Vehicles string
 	PhoneNo string

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -1,10 +1,13 @@
 package server
 
 import (
-	"github.com/parkmenow/PMN-api/constants"
-
+	"encoding/json"
+	"fmt"
 	"github.com/gin-gonic/gin"
 	"github.com/jinzhu/gorm"
+
+	"github.com/parkmenow/PMN-api/constants"
+	"github.com/parkmenow/PMN-api/models"
 )
 
 // getHello defines the endpoint for initial test
@@ -14,4 +17,19 @@ func getHello(c *gin.Context) {
 
 func getDB(c *gin.Context) *gorm.DB {
 	return c.MustGet(constants.ContextDB).(*gorm.DB)
+}
+
+func userRegistration(c *gin.Context) {
+	buf := make([]byte, 1024)
+	num, _ := c.Request.Body.Read(buf)
+	reqBody := string(buf[0:num])
+
+	fmt.Println(num)
+	db := getDB(c)
+	var newuser models.User
+
+	json.Unmarshal([]byte(reqBody), &newuser)
+	db.Create(&newuser)
+
+	c.JSON(201, "User added successfully!")
 }

--- a/server/router.go
+++ b/server/router.go
@@ -11,4 +11,5 @@ func defineRoutes(router *gin.Engine) {
 	// Initial version your API
 	v1 := router.Group("/api/v1")
 	v1.GET("/", getHello)
+	v1.POST("/signup", userRegistration)
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,19 +1,24 @@
 package server_test
 
 import (
+	"bytes"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 
 	"github.com/gin-gonic/gin"
+	"github.com/jinzhu/gorm"
+	_ "github.com/jinzhu/gorm/dialects/sqlite"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	
+
+	"github.com/parkmenow/PMN-api/models"
 	. "github.com/parkmenow/PMN-api/server"
 )
 
 // performRequest performs a http request and returns the response
-func performRequest(r http.Handler, method, path string) *httptest.ResponseRecorder {
-	req, _ := http.NewRequest(method, path, nil)
+func performRequest(r http.Handler, method, path string, reqbody string) *httptest.ResponseRecorder {
+	req, _ := http.NewRequest(method, path, bytes.NewBuffer([]byte(reqbody)))
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 	return w
@@ -21,20 +26,30 @@ func performRequest(r http.Handler, method, path string) *httptest.ResponseRecor
 
 var _ = Describe("Server", func() {
 
-	// Setup initial pointer variable to be reused for each new test
 	var (
+		db       *gorm.DB
 		router   *gin.Engine
 		response *httptest.ResponseRecorder
 	)
 
 	BeforeEach(func() {
-		router = CreateRouter()
+		d, err := gorm.Open("sqlite3", "pmn.db")
+		db = d
+		if err != nil {
+			panic(err)
+		}
+
+		router = CreateRouter(db)
+	})
+
+	AfterEach(func() {
+		db.Close()
 	})
 
 	Describe("Version 1 API at /api/v1", func() {
 		Describe("The / endpoint or helloworld endpoint", func() {
 			BeforeEach(func() {
-				response = performRequest(router, "GET", "/api/v1/")
+				response = performRequest(router, "GET", "/api/v1/", "")
 			})
 
 			It("Returns with Status 200", func() {
@@ -47,4 +62,33 @@ var _ = Describe("Server", func() {
 		})
 	})
 
+	Describe("POST the /signup endpoint", func() {
+		BeforeEach(func() {
+			response = performRequest(router, "POST", "/api/v1/signup", jsonSignUp)
+		})
+		It("Returns with Status 201", func() {
+			Expect(response.Code).To(Equal(201))
+		})
+		It("Added a new User", func() {
+			newuser := models.User{}
+			json.Unmarshal([]byte(jsonSignUp), &newuser)
+			var user models.User
+			db.Last(&user)
+			Expect(newuser.UName).To(Equal(user.UName))
+		})
+	})
+
 })
+
+// sign up user testing
+var jsonSignUp = `{
+	"FName": "ssssss",
+	"LName": "pppppp",
+	"UName": "subodh101",
+	"Password": "password",
+	"Email": "subodh.pushkar@gmail.com",
+	"PhoneNo": "9911991199",
+	"Line1" : "1-5-5, 1108",
+	"Line2" : "Higashi-ojima",
+	"Pincode": "132-0034"
+}`


### PR DESCRIPTION
- Added the user registration signup at `/api/v1/signup`
- Added the test for it
- For running the tests, copy the `pmn.db` inside server/ folder 

Note: I have closed the previous PR since the whole structure has changed.