### PR TITLE
Adds POST /dashboard/regSpot API endpoint

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -118,3 +118,13 @@ func regParkingSpot(c *gin.Context) {
 	c.JSON(201, "Listed a new parking Spot Successfully!")
 
 }
+
+func regSpot(c *gin.Context) {
+	var spot models.Spot
+	//var spots []models.Spot
+	db := getDB(c)
+	c.BindJSON(&spot)
+	db.Create(&spot)
+	//db.Where("property_id = ?", spot.PropertyID).Find(&spots)
+	c.JSON(200, "Successfully Added Spot")
+}

--- a/server/router.go
+++ b/server/router.go
@@ -19,4 +19,5 @@ func defineRoutes(router *gin.Engine) {
 	user.Use(authMiddleware.MiddlewareFunc())
 	user.POST("/parkmenow", fetchParkingSpots)
 	user.POST("/regparking", regParkingSpot)
+	user.POST("/regSpot", regSpot)
 }


### PR DESCRIPTION
Adds POST /dashboard/regSpot API endpoint
Creates a new SPOT under the given PropertyID. 

input : 	{
        "Type" : 1,
        "ImageURL": "https://www.archdaily.com/878629/simple-house-moon-hoon/59a4c624b22e389d3e0002a3-simple-house-moon-hoon-image",
        "Description": "Very beautiful can park a cycle",
        "PropertyID": 3
    }

output: "Successfully Added Spot"