### PR TITLE
Adds PATCH /dashboard/modifySpot API endpoint

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -136,3 +136,13 @@ func regSlot(c *gin.Context) {
 	db.Create(&slot)
 	c.JSON(200, "Successfully Added Slot")
 }
+
+func modifySpot(c *gin.Context) {
+	var spot models.Spot
+	var modSpot models.Spot
+	db := getDB(c)
+	c.BindJSON(&modSpot)
+	fmt.Println(modSpot)
+	db.Where("id = ?", modSpot.ID).First(&spot).Update(&modSpot)
+	c.JSON(200, "Successfully Modified Spot")
+}

--- a/server/router.go
+++ b/server/router.go
@@ -21,4 +21,5 @@ func defineRoutes(router *gin.Engine) {
 	user.POST("/regparking", regParkingSpot)
 	user.POST("/regSpot", regSpot)
 	user.POST("/regSlot", regSlot)
+	user.PATCH("/modifySpot", modifySpot)
 }


### PR DESCRIPTION
Adds PATCH /dashboard/modifySpot API endpoint
Creates a new SLOT under the given SPOTID as ID.

input : {
	"ID": 1,
    "Type" : 1,
    "ImageURL": "https://www.archdaily.com/878629/simple-house-moon-hoon/59a4c624b22e389d3e0002a3-simple-house-moon-hoon-image",
    "Description": "beautiful can park a cycle",
    "PropertyID": 1
}

output: "Successfully Modified Spot"