### PR TITLE
Correct the booking refunds after cancelling a booking

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -340,14 +340,16 @@ func cancelBooking(c *gin.Context){
 	var user models.User
 	db.Where("id=?", booking.UserID).Find(&user)
 	fmt.Println(user.Wallet)
-	user.Wallet = int64((100-cancellationPercentage) * booking.Price/100)
+	user.Wallet = user.Wallet + int64((100-cancellationPercentage) * booking.Price/100)
 	db.Save(&user)
 
 	// 4) Add 10% of amount to owner of the spot
-	var owner models.User
+	var owner models.Owner
+	var ownerUser models.User
 	db.Where("id=?", booking.OwnerID).Find(&owner)
-	owner.Wallet = int64(cancellationPercentage * booking.Price/100)
-	db.Save(&owner)
+	db.Where("id= ?", owner.UserID).Find(&ownerUser)
+	ownerUser.Wallet = ownerUser.Wallet + int64(cancellationPercentage * booking.Price/100)
+	db.Save(&ownerUser)
 
 	// 5) Inform the API saying the task is done, with status code 200 and JSON that booking is cancelled
 	c.JSON(200, gin.H{"info":"Booking is cancelled",})

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -348,7 +348,7 @@ func cancelBooking(c *gin.Context){
 	var ownerUser models.User
 	db.Where("id=?", booking.OwnerID).Find(&owner)
 	db.Where("id= ?", owner.UserID).Find(&ownerUser)
-	ownerUser.Wallet = ownerUser.Wallet + int64(cancellationPercentage * booking.Price/100)
+	ownerUser.Wallet = ownerUser.Wallet - int64(cancellationPercentage * booking.Price/100)
 	db.Save(&ownerUser)
 
 	// 5) Inform the API saying the task is done, with status code 200 and JSON that booking is cancelled

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -348,7 +348,7 @@ func cancelBooking(c *gin.Context){
 	var ownerUser models.User
 	db.Where("id=?", booking.OwnerID).Find(&owner)
 	db.Where("id= ?", owner.UserID).Find(&ownerUser)
-	ownerUser.Wallet = ownerUser.Wallet - int64(cancellationPercentage * booking.Price/100)
+	ownerUser.Wallet = ownerUser.Wallet - int64((100-cancellationPercentage) * booking.Price/100)
 	db.Save(&ownerUser)
 
 	// 5) Inform the API saying the task is done, with status code 200 and JSON that booking is cancelled


### PR DESCRIPTION
OwnerID and userID of the owner can be different
- hence after cancellation of the booking the money should be added to the wallet of the user whose id=(booking.OwnerID).UserID

Booking refunds should be increased and decreased from the current amount in the wallets of the user and owner.
